### PR TITLE
Workarounds for eager / torch.compile mode failures in HPU

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -731,6 +731,8 @@ class Linear(nn.Module, LoraLayer):
                 x = self._cast_input_dtype(x, lora_A.weight.dtype)
                 if active_adapter not in self.lora_variant:  # vanilla LoRA
                     lora_result = lora_B(lora_A(dropout(x))) * scaling
+                    if torch.compiler.is_dynamo_compiling():
+                         torch._dynamo.graph_break()
                     result = result + lora_result.to(torch_result_dtype)
                 else:
                     result = self.lora_variant[active_adapter].forward(

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -730,7 +730,8 @@ class Linear(nn.Module, LoraLayer):
                 scaling = self.scaling[active_adapter]
                 x = self._cast_input_dtype(x, lora_A.weight.dtype)
                 if active_adapter not in self.lora_variant:  # vanilla LoRA
-                    result = result + lora_B(lora_A(dropout(x))) * scaling
+                    lora_result = lora_B(lora_A(dropout(x))) * scaling
+                    result = result + lora_result.to(torch_result_dtype)
                 else:
                     result = self.lora_variant[active_adapter].forward(
                         self,


### PR DESCRIPTION
Captures two workarounds:

- A change that avoids an op with mixed bf16 and fp8 tensors. This fixes the eager mode failure, but not when `torch.compile` is involved.
- For the `torch.compile` failure, a forced graph break appears to resolve the issue. So the code does this conditionally.